### PR TITLE
Fixes paths to be absolute as required by SonarQube

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,9 @@ export = class SonarQubeFormatter {
     if (this.options.hasResultData) {
       for (const filePath of Object.keys(results.files)) {
         let result = results.files[filePath];
-        let relativePath = path.relative(this.options.workingDirectory, result.filePath);
+        let absolutePath = path.isAbsolute(result.filePath)
+          ? result.filePath
+          : path.resolve(this.options.workingDirectory, result.filePath);
 
         for (const message of result.messages) {
           issues.push({
@@ -56,7 +58,7 @@ export = class SonarQubeFormatter {
             type: SONARQUBE_TYPE[message.severity as Severity],
             primaryLocation: {
               message: message.message,
-              filePath: relativePath,
+              filePath: absolutePath,
               textRange: {
                 startLine: message.line,
                 startColumn: message.column,

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -70,7 +70,7 @@ describe('SonarQube Formatter', () => {
             \\"type\\": \\"CODE_SMELL\\",
             \\"primaryLocation\\": {
               \\"message\\": \\"Non-translated string used\\",
-              \\"filePath\\": \\"app/templates/application.hbs\\",
+              \\"filePath\\": \\"/private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-83160IQlqAstCf8BJ/app/templates/application.hbs\\",
               \\"textRange\\": {
                 \\"startLine\\": 1,
                 \\"startColumn\\": 4,
@@ -86,7 +86,7 @@ describe('SonarQube Formatter', () => {
             \\"type\\": \\"CODE_SMELL\\",
             \\"primaryLocation\\": {
               \\"message\\": \\"Non-translated string used\\",
-              \\"filePath\\": \\"app/templates/application.hbs\\",
+              \\"filePath\\": \\"/private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-83160IQlqAstCf8BJ/app/templates/application.hbs\\",
               \\"textRange\\": {
                 \\"startLine\\": 1,
                 \\"startColumn\\": 25,
@@ -129,7 +129,7 @@ describe('SonarQube Formatter', () => {
             \\"type\\": \\"BUG\\",
             \\"primaryLocation\\": {
               \\"message\\": \\"Non-translated string used\\",
-              \\"filePath\\": \\"app/templates/application.hbs\\",
+              \\"filePath\\": \\"/private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-83160m1PGmFBDlaCq/app/templates/application.hbs\\",
               \\"textRange\\": {
                 \\"startLine\\": 1,
                 \\"startColumn\\": 4,
@@ -145,7 +145,7 @@ describe('SonarQube Formatter', () => {
             \\"type\\": \\"BUG\\",
             \\"primaryLocation\\": {
               \\"message\\": \\"Non-translated string used\\",
-              \\"filePath\\": \\"app/templates/application.hbs\\",
+              \\"filePath\\": \\"/private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-83160m1PGmFBDlaCq/app/templates/application.hbs\\",
               \\"textRange\\": {
                 \\"startLine\\": 1,
                 \\"startColumn\\": 25,


### PR DESCRIPTION
In order to correctly import external issues into SonarQube, the format needs to include file paths that are absolute, which match what SonarQube's scanners use when running against the project's files. If an unrecognized path is detected, the external issues import will be skipped. 

This fix ensures that we're using absolute paths always.