### PR TITLE
Generate a template json file when there is no output from ETL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,31 +43,29 @@ export = class SonarQubeFormatter {
   format(results: EmberTemplateLintResults) {
     const issues = [];
 
-    if (this.options.hasResultData) {
-      for (const filePath of Object.keys(results.files)) {
-        let result = results.files[filePath];
-        let absolutePath = path.isAbsolute(result.filePath)
-          ? result.filePath
-          : path.resolve(this.options.workingDirectory, result.filePath);
+    for (const filePath of Object.keys(results.files)) {
+      let result = results.files[filePath];
+      let absolutePath = path.isAbsolute(result.filePath)
+        ? result.filePath
+        : path.resolve(this.options.workingDirectory, result.filePath);
 
-        for (const message of result.messages) {
-          issues.push({
-            engineId: 'ember-template-lint',
-            ruleId: message.rule,
-            severity: SONARQUBE_SEVERITY[message.severity as Severity],
-            type: SONARQUBE_TYPE[message.severity as Severity],
-            primaryLocation: {
-              message: message.message,
-              filePath: absolutePath,
-              textRange: {
-                startLine: message.line,
-                startColumn: message.column,
-                endLine: message.endLine,
-                endColumn: message.endColumn,
-              },
+      for (const message of result.messages) {
+        issues.push({
+          engineId: 'ember-template-lint',
+          ruleId: message.rule,
+          severity: SONARQUBE_SEVERITY[message.severity as Severity],
+          type: SONARQUBE_TYPE[message.severity as Severity],
+          primaryLocation: {
+            message: message.message,
+            filePath: absolutePath,
+            textRange: {
+              startLine: message.line,
+              startColumn: message.column,
+              endLine: message.endLine,
+              endColumn: message.endColumn,
             },
-          });
-        }
+          },
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
Currently there is no json file generated if there is no issue output from `ember-template-lint`. We need to output a json file like below to make sonar scan work.
```json
{"issues":[]}
```

## Test
npm test passed.